### PR TITLE
fix: change loader for .tsx files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,11 +111,11 @@ function getEsbuildLoader(args: OnLoadArgs) {
 
   switch (resolvedExtName) {
     case '.ts':
-    case '.tsx':
     case '.mts':
     case '.cts':
       return 'ts';
     case '.jsx':
+    case '.tsx':
       return 'tsx';
     case '.json':
       return 'json';


### PR DESCRIPTION
Currently loader for `.tsx` files is set as `ts`, which doesn't seem to be correct and because of that if this plugins is used in combination with `esbuild-plugin-swc` plugin, then it gives compilation error.

Changing the loader to `tsx` seems correct and it also fixes the compilation error.